### PR TITLE
Print missing Jefit exercises in Python

### DIFF
--- a/python-script/converter.py
+++ b/python-script/converter.py
@@ -115,6 +115,12 @@ def convert_to_hevy_format(df):
     out["Workout Notes"] = '"Sorry🫡 Script: Imported from JeFit"'
     out["RPE"] = ""
 
+    unique_jefit_exercises = set(e.strip('"') for e in out["Exercise Name"])
+    if missing_exercises := unique_jefit_exercises - set(mapper.keys()):
+        print("Warning: The following exercises are not in the mapper:")
+        for exercise in missing_exercises:
+            print(f"- {exercise!r}")
+
     out["Exercise Name"] = out["Exercise Name"].map(
         lambda x: mapper.get(x.strip('"'), x)
     )


### PR DESCRIPTION
Prints custom exercises in the following format using the Python script:
```
Warning: The following exercises are not in the mapper:
- 'Dumbbell Wrist Curl (Palms Down)'
- 'Band Wrist Curl (Palm Up)'
- 'Wrist Circles'
- 'Dumbbell Wood Chop'
- 'Cobra'
```